### PR TITLE
Respect cancel during export

### DIFF
--- a/grails-app/services/com/recomdata/transmart/data/export/DataExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/DataExportService.groovy
@@ -124,7 +124,8 @@ class DataExportService {
                                 // List<String> conceptPaths
                                 // String dataType
                                 // String studyDir
-                                retVal = highDimExportService.exportHighDimData(splitAttributeColumn: false,
+                                retVal = highDimExportService.exportHighDimData(jobName: jobDataMap.jobName,
+                                                                                splitAttributeColumn: false,
                                                                                 resultInstanceId: resultInstanceIdMap[subset],
                                                                                 conceptPaths: selection[subset][selectedFile].selector,
                                                                                 dataType: selectedFile,

--- a/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
@@ -103,10 +103,10 @@ class HighDimExportService {
             for (BioMarkerDataRow<Map<String, String>> datarow : tabularResult) {
                 for (AssayColumn assay : assayList) {
                     rowsFound++
+                    // test periodically if the job is cancelled
                     if (rowsFound % 1024 == 0 && jobIsCancelled(jobName)) {
                         return null
                     }
-                    //if (rowsFound > 20) break writeloop
 
                     Map<String, String> data = datarow[assay]
 


### PR DESCRIPTION
High dimension data export now periodically checks if the job has been cancelled, and if so aborts. This
prevents transmart from failing to quit if a long running export task is still busy.
