### PR TITLE
UAT-128 fix

### DIFF
--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -404,49 +404,51 @@ Ext.onReady(function () {
             }
         );
 
+        // **************
+        // Comparison tab
+        // **************
+
         queryPanel = new Ext.Panel(
-            {
-                id: 'queryPanel',
-                title: 'Comparison',
-                region: 'north',
-                height: 340,
-                autoScroll: true,
-                split: true,
-                autoLoad: {
-                    url: pageInfo.basePath + '/panels/subsetPanel.html',
-                    scripts: true,
-                    nocache: true,
-                    discardUrl: true,
-                    method: 'POST'//,
-                    //callback: loadOntPanel
-                },
-                collapsible: true,
-                titleCollapse: false,
-                animCollapse: false,
-                listeners: {
-                    activate: function () {
-                        GLOBAL.Analysis = "Advanced";
+        {
+            id: 'queryPanel',
+            title: 'Comparison',
+            region: 'north',
+            height: 340,
+            autoScroll: true,
+            split: true,
+            autoLoad: {
+                url: pageInfo.basePath + '/panels/subsetPanel.html',
+                scripts: true,
+                nocache: true,
+                discardUrl: true,
+                method: 'POST'
+            },
+            collapsible: true,
+            titleCollapse: false,
+            animCollapse: false,
+            listeners: {
+                activate: function () {
+                    GLOBAL.Analysis = "Advanced";
+                }
+            },
+            bbar: new Ext.StatusBar({
+                // Status bar to show the progress of generating heatmap and other advanced workflows
+                id: 'asyncjob-statusbar',
+                defaultText: 'Ready',
+                defaultIconCls: 'default-icon',
+                text: 'Ready',
+                statusAlign: 'right',
+                iconCls: 'ready-icon',
+                items: [
+                    {
+                        xtype: 'button',
+                        id: 'cancjob-button',
+                        text: 'Cancel',
+                        hidden: true
                     }
-                },
-                bbar: new Ext.StatusBar({
-                    // Status bar to show the progress of generating heatmap and other advanced workflows
-                    id: 'asyncjob-statusbar',
-                    defaultText: 'Ready',
-                    defaultIconCls: 'default-icon',
-                    text: 'Ready',
-                    statusAlign: 'right',
-                    iconCls: 'ready-icon',
-                    items: [
-                        {
-                            xtype: 'button',
-                            id: 'cancjob-button',
-                            text: 'Cancel',
-                            hidden: true
-                        }
-                    ]
-                })
-            }
-        );
+                ]
+            })
+        });
 
         resultsPanel = new Ext.Panel(
             {
@@ -484,6 +486,10 @@ Ext.onReady(function () {
             }
         );
 
+        // **************
+        // Grid view tab
+        // **************
+
         analysisGridPanel = new Ext.Panel(
             {
                 id: 'analysisGridPanel',
@@ -500,38 +506,45 @@ Ext.onReady(function () {
             }
         );
 
-        analysisPanel = new Ext.Panel (
-            {
-                id: 'analysisPanel',
-                title: 'Summary Statistics',
-                region: 'center',
-                fitToFrame: true,
-                listeners: {
-                    activate: function (p) {
-                        if (isSubsetQueriesChanged() || !Ext.get('analysis_title')) {
-                            p.body.mask("Loading...", 'x-mask-loading');
-                            runAllQueries(getSummaryStatistics, p);
-                            activateTab();
-                            onWindowResize();
-                        }
-                    },
-                    deactivate: function () {
-                        resultsTabPanel.tools.help.dom.style.display = "none";
-                    },
-                    'afterLayout': {
-                        fn: function (el) {
-                            onWindowResize();
-                        }
+        // ******************
+        // Summary Statistics
+        // ******************
+
+        analysisPanel = new Ext.Panel ({
+            id: 'analysisPanel',
+            title: 'Summary Statistics',
+            region: 'center',
+            fitToFrame: true,
+            listeners: {
+                activate: function (p) {
+                    if (isSubsetQueriesChanged(p.subsetQueries) || !Ext.get('analysis_title')) {
+                        p.body.mask("Loading...", 'x-mask-loading');
+                        runAllQueries(getSummaryStatistics, p);
+                        activateTab();
+                        onWindowResize();
                     }
                 },
-                autoScroll: true,
-                // tbar : tb2,
-                html: '<div style="text-align:center;font:12pt arial;width:100%;height:100%;"><table style="width:100%;height:100%;"><tr><td align="center" valign="center">Drag concepts to this panel to view a breakdown of the subset by that concept</td></tr></table></div>',
-                split: true,
-                closable: false,
-                height: 90
-            }
-        );
+                deactivate: function () {
+                    resultsTabPanel.tools.help.dom.style.display = "none";
+                },
+                'afterLayout': {
+                    fn: function (el) {
+                        onWindowResize();
+                    }
+                }
+            },
+            autoScroll: true,
+            html: '<div style="text-align:center;font:12pt arial;width:100%;height:100%;">' +
+                '<table style="width:100%;height:100%;"><tr><td align="center" valign="center">Drag concepts ' +
+                'to this panel to view a breakdown of the subset by that concept</td></tr></table></div>',
+            split: true,
+            closable: false,
+            height: 90
+        });
+
+        // ************
+        // Data Exports
+        // ************
 
         analysisDataExportPanel = new Ext.Panel(
             {
@@ -543,7 +556,7 @@ Ext.onReady(function () {
                 layout: 'fit',
                 listeners: {
                     activate: function (p) {
-                        if (isSubsetQueriesChanged() || !Ext.get('dataTypesGridPanel')) {
+                        if (isSubsetQueriesChanged(p.subsetQueries) || !Ext.get('dataTypesGridPanel')) {
                             p.body.mask("Loading...", 'x-mask-loading');
                             runAllQueries(getDatadata, p);
                             return;
@@ -558,6 +571,10 @@ Ext.onReady(function () {
                 collapsible: true
             }
         );
+
+        // ******************
+        // Advanced Workflow
+        // ******************
 
         dataAssociationPanel = new Ext.Panel(
             {
@@ -580,7 +597,7 @@ Ext.onReady(function () {
                     evalScripts: true
                 },
                 listeners: {
-                    activate: function () {
+                    activate: function (p) {
                         /**
                          * routines when activating advanced workflow tab
                          * @private
@@ -592,8 +609,8 @@ Ext.onReady(function () {
                             onWindowResize();
                         }
 
-                        if (isSubsetQueriesChanged()) {
-                            runAllQueries(_activateAdvancedWorkflow);
+                        if (isSubsetQueriesChanged(p.subsetQueries)) {
+                            runAllQueries(_activateAdvancedWorkflow, p);
                         }
 
                         _activateAdvancedWorkflow();
@@ -607,6 +624,10 @@ Ext.onReady(function () {
                 collapsible: true
             }
         );
+
+        // ******************
+        // Export Jobs
+        // ******************
 
         analysisExportJobsPanel = new Ext.Panel(
             {
@@ -2109,9 +2130,13 @@ function runAllQueries(callback, panel) {
     STATE.QueryRequestCounter = subsetstorun;
     /* set the number of requests before callback is fired for runquery complete */
 
+    // init panel's subset query array if it's not existing yet
+    if (!panel.subsetQueries) panel.subsetQueries = ["", "", ""];
+
     // iterate through all subsets calling the ones that need to be run
     for (var i = 1; i <= GLOBAL.NumOfSubsets; i++) {
         if (!isSubsetEmpty(i)) {
+            panel.subsetQueries[i] = getSubsetQuery(i); // set subset queries to the selected tab
             runQuery(i, callback);
         }
     }
@@ -2139,18 +2164,22 @@ function getSubsetQuery (subsetId) {
  * Check if there're any changes in both subsets
  * @returns {boolean}
  */
-function isSubsetQueriesChanged() {
+function isSubsetQueriesChanged (referenceQueries) {
     var retVal = false;
 
     for (var i = 1; i <= GLOBAL.NumOfSubsets; i++) {
 
+        // get fresh subset query
         var _newQuery = getSubsetQuery(i);
-        retVal = GLOBAL.CurrentSubsetQueries[i] != _newQuery ? true : false;
-        if (retVal) {
-            break;
+
+        if (referenceQueries) {
+            // check if reference query is the same as the new query
+            // return true if it's changed.
+            retVal = referenceQueries[i] != _newQuery ? true : false;
         }
+
+        if (retVal) break;
     }
-    console.log("isSubsetQueriesChanged", retVal);
     return retVal;
 }
 
@@ -2160,7 +2189,7 @@ function runQuery(subset, callback) {
     }
 
     var query = getCRCQueryRequest(subset);
-    var _subsetQuery = getSubsetQuery(subset);
+
     // first subset
     queryPanel.el.mask('Getting subset ' + subset + '...', 'x-mask-loading');
     Ext.Ajax.request(
@@ -2177,9 +2206,6 @@ function runQuery(subset, callback) {
             timeout: '600000'
         }
     );
-
-    // save query to global variable
-    GLOBAL.CurrentSubsetQueries[subset] = _subsetQuery;
 
     if (GLOBAL.Debug) {
         resultsPanel.setBody("<div style='height:400px;width500px;overflow:auto;'>" + Ext.util.Format.htmlEncode(query) + "</div>");
@@ -2214,6 +2240,9 @@ function runQueryComplete(result, subset, callback) {
 
     // Current code requires us to set CurrentSubsetIDs regardless of error status...
     GLOBAL.CurrentSubsetIDs[subset] = jsonRes.id ? jsonRes.id : -1;
+
+    // Save query to global variable
+    GLOBAL.CurrentSubsetQueries[subset] = getSubsetQuery(subset);
 
     if (subset === null) { // if single subset
 


### PR DESCRIPTION
To change the behaviour of checking whether subset is changed or not when user clicking advanced workflow's tabs. New way is to store the subset query as reference in the tab object and then compare it when user click the tab and refresh the subset only when user's changed the subset.
