### PR TITLE
Refactoring of export functionality and implementation of VCF exporter

### DIFF
--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -20,9 +20,11 @@ import org.springframework.security.core.session.SessionRegistryImpl
 import org.springframework.security.web.authentication.session.ConcurrentSessionControlStrategy
 import org.springframework.security.web.session.ConcurrentSessionFilter
 import org.transmart.marshallers.MarshallerRegistrarService
+import org.transmartproject.export.HighDimExporter
 
 beans = {
-
+    xmlns context:"http://www.springframework.org/schema/context"
+    
     if (grailsApplication.config.org.transmart.security.samlEnabled) {
         importBeans('classpath:/spring/spring-security-saml.xml')
     }
@@ -41,6 +43,13 @@ beans = {
 		expiredUrl = '/login'
 	}
 
+    context.'component-scan'('base-package': 'org.transmartproject.export') {
+        context.'include-filter'(
+                type:       'assignable',
+                expression: HighDimExporter.canonicalName)
+    }
+    
+    
     //overrides bean implementing GormUserDetailsService?
 	userDetailsService(com.recomdata.security.AuthUserDetailsService)
 

--- a/grails-app/services/com/recomdata/transmart/data/export/DataExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/DataExportService.groovy
@@ -55,6 +55,8 @@ class DataExportService {
         def resultInstanceIdMap = jobDataMap.result_instance_ids
         def subsetSelectedFilesMap = jobDataMap.subsetSelectedFilesMap
         def subsetSelectedPlatformsByFiles = jobDataMap.subsetSelectedPlatformsByFiles
+        def highDimDataTypes = jobDataMap.highDimDataTypes
+        
         def mergeSubSet = jobDataMap.mergeSubset
 		//Hard-coded subsets to count 2
 		def subsets = ['subset1', 'subset2']
@@ -78,6 +80,7 @@ class DataExportService {
 			def snpFilesMap = [:]
             def selectedFilesList = subsetSelectedFilesMap.get(subset) ?: []
 
+            // Add all High Dimensional data types available, to the list
             selectedFilesList?.addAll((selection[subset]?.keySet() ?: []) - ['clinical'])
 
 			if (null != selectedFilesList && !selectedFilesList.isEmpty()) {
@@ -126,13 +129,21 @@ class DataExportService {
                                 // String dataType
                                 // String studyDir
                                 log.info "Exporting " + selectedFile + " using core api" 
-                                retVal = highDimExportService.exportHighDimData(jobName: jobDataMap.jobName,
-                                                                                splitAttributeColumn: false,
-                                                                                resultInstanceId: resultInstanceIdMap[subset],
-                                                                                conceptPaths: selection[subset][selectedFile].selector,
-                                                                                dataType: selectedFile,
-                                                                                studyDir: studyDir
-                                                                                )
+                                
+                                // For now we ignore the information about the platforms to 
+                                // export. All data that matches the selected concepts
+                                // is exported
+                                highDimDataTypes[subset][selectedFile].keySet().each { format ->
+                                    log.info "  Using format " + format 
+                                    retVal = highDimExportService.exportHighDimData(jobName: jobDataMap.jobName,
+                                                                                    splitAttributeColumn: false,
+                                                                                    resultInstanceId: resultInstanceIdMap[subset],
+                                                                                    conceptPaths: selection[subset][selectedFile].selector,
+                                                                                    dataType: selectedFile,
+                                                                                    format: format,
+                                                                                    studyDir: studyDir
+                                                                                    )
+                                }
                                 log.info "Exported " + selectedFile + " using core api"
                                  
 								//filesDoneMap is used for building the Clinical Data query

--- a/grails-app/services/com/recomdata/transmart/data/export/ExportMetadataService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/ExportMetadataService.groovy
@@ -281,7 +281,7 @@ class ExportMetadataService {
                 
                 subset1: exporters.collect {
                     [
-                        fileType: it.format,
+                        fileType: "." + it.format,
                         dataTypeHasCounts: true,
                         dataFormat: it.description,
                         fileDataCount: highDimRow.subset1 ? highDimRow.subset1.size() : 0,
@@ -290,7 +290,7 @@ class ExportMetadataService {
                 },
                 subset2: exporters.collect {
                     [
-                        fileType: it.format,
+                        fileType: "." + it.format,
                         dataTypeHasCounts: true,
                         dataFormat: it.description,
                         fileDataCount: highDimRow.subset2 ? highDimRow.subset2.size() : 0,

--- a/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
@@ -78,7 +78,10 @@ class ExportService {
      * 
      * Each selected checkbox has the format
      *      <subset_id>_<datatype>_<exportformat>_<platform>
-     *      
+     * where exportformat is a string, prepended with a dot
+     * (for compatibility reasons). That dot is removed from the
+     * string in this method
+     * 
      * @param selectedCheckboxList List with selected checkboxes
      * @return
      */

--- a/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
@@ -73,6 +73,41 @@ class ExportService {
 		return result
 	}
 	
+    /**
+     * Converts the list of selected checkboxes, into a map
+     * 
+     * Each selected checkbox has the format
+     *      <subset_id>_<datatype>_<exportformat>_<platform>
+     *      
+     * @param selectedCheckboxList List with selected checkboxes
+     * @return
+     */
+    protected Map getHighDimDataTypesAndFormats( selectedCheckboxList ) {
+        Map formats = [:]
+        
+        selectedCheckboxList.each { 
+            String[] parts = it.split("_")
+            
+            // The third part is the export format. However,
+            // for compatibility reasons the format is prepended
+            // with a dot. That is not necessary anymore
+            def format = parts[2][1..-1] 
+            
+            if( !formats.containsKey( parts[0] ) )
+                formats[parts[0]] = [:]
+                
+            if( !formats[parts[0]].containsKey( parts[1] ) )
+                formats[parts[0]][parts[1]] = [:]
+
+            if( !formats[parts[0]][parts[1]].containsKey( format ) )
+                formats[parts[0]][parts[1]][format] = []
+                
+            formats[parts[0]][parts[1]][format] << parts[3]
+        }
+        
+        formats
+    }
+    
 	def private Map getSubsetSelectedFilesMap(selectedCheckboxList) {
 		def subsetSelectedFilesMap = [:]
         
@@ -149,6 +184,7 @@ class ExportService {
 				}
 			}
 		}
+        
 		return subsetSelectedPlatformsByFiles
 	}
 	
@@ -174,14 +210,14 @@ class ExportService {
 			if (checkboxList && !checkboxList?.trim().equals("")) tempArray.add(checkboxList)
 			checkboxList = tempArray
 		}
-		
+        
 		def jdm = new JobDataMap()
 		jdm.put("analysis", params.analysis)
 		jdm.put("userName", userName)
 		jdm.put("jobName", params.jobName)
 		jdm.put("result_instance_ids", resultInstanceIdHashMap);
 		jdm.selection = params.selection
-		//jdm.put("datatypes", jobDataTypes);
+        jdm.highDimDataTypes = getHighDimDataTypesAndFormats( checkboxList )
 		jdm.put("subsetSelectedPlatformsByFiles", getsubsetSelectedPlatformsByFiles(checkboxList))
 		jdm.put("checkboxList", checkboxList);
 		jdm.put("subsetSelectedFilesMap", getSubsetSelectedFilesMap(params.selectedSubsetDataTypeFiles))

--- a/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
@@ -123,7 +123,9 @@ class ExportService {
 		def subsetSelectedPlatformsByFiles=[:]
 		//Split the list on commas first, each box is seperated by ",".
 		checkboxList.each {checkboxItem ->
-			//Split the item by "_" to get the different attributes.
+			// Split the item by "_" to get the different attributes.
+            // Attributes are: <subset_id>_<datatype>_<exportformat>_<platform>
+            // e.g. subset1_mrna_TSV_GPL570
 			String[] checkboxItemArray = StringUtils.split(checkboxItem, "_")
 			
 			//The first item is the subset name.

--- a/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
@@ -16,7 +16,7 @@
  * 
  *
  ******************************************************************/
-  
+
 
 package com.recomdata.transmart.data.export
 
@@ -37,42 +37,42 @@ import com.recomdata.transmart.validate.RequestValidator
 class ExportService {
 
     static transactional = true
-	def i2b2HelperService
-	def i2b2ExportHelperService
-	def jobResultsService
-	def asyncJobService
-	def quartzScheduler
-	def grailsApplication
-	def dataExportService
-	
-	def createExportDataAsyncJob(params, userName) {
-		def analysis = params.analysis
-		def jobStatus = "Started"
-		
-		def newJob = new AsyncJob(lastRunOn:new Date())
-		newJob.save()
-		
-		def jobName = userName + "-" + analysis + "-" + newJob.id
-		newJob.jobName = jobName
-		newJob.jobStatus = jobStatus
-		newJob.jobType = analysis
-		newJob.altViewerURL = 'Test'
-		//params.querySummary1 + ((params.querySummary2 != '') ? ' <br/> ' + params.querySummary2 : '')
-		newJob.save()
-		
-		jobResultsService[jobName] = [:]
-		//jobResultsService[jobName]['altViewerURL'] = params.querySummary1 + ((params.querySummary2 != '') ? ' <br/> ' + params.querySummary2 : '')
-		def querySummary = 'Subset 1:' + params.querySummary1 + ((params.querySummary2 != '') ? ' <br/> Subset 2:' + params.querySummary2 : '')
-		asyncJobService.updateStatus(jobName, jobStatus, null, querySummary, null)
-		
-		log.debug("Sending ${newJob.jobName} back to the client")
-		JSONObject result = new JSONObject()
-		result.put("jobName", jobName)
-		result.put("jobStatus", jobStatus)
-		
-		return result
-	}
-	
+    def i2b2HelperService
+    def i2b2ExportHelperService
+    def jobResultsService
+    def asyncJobService
+    def quartzScheduler
+    def grailsApplication
+    def dataExportService
+
+    def createExportDataAsyncJob(params, userName) {
+        def analysis = params.analysis
+        def jobStatus = "Started"
+
+        def newJob = new AsyncJob(lastRunOn:new Date())
+        newJob.save()
+
+        def jobName = userName + "-" + analysis + "-" + newJob.id
+        newJob.jobName = jobName
+        newJob.jobStatus = jobStatus
+        newJob.jobType = analysis
+        newJob.altViewerURL = 'Test'
+        //params.querySummary1 + ((params.querySummary2 != '') ? ' <br/> ' + params.querySummary2 : '')
+        newJob.save()
+
+        jobResultsService[jobName] = [:]
+        //jobResultsService[jobName]['altViewerURL'] = params.querySummary1 + ((params.querySummary2 != '') ? ' <br/> ' + params.querySummary2 : '')
+        def querySummary = 'Subset 1:' + params.querySummary1 + ((params.querySummary2 != '') ? ' <br/> Subset 2:' + params.querySummary2 : '')
+        asyncJobService.updateStatus(jobName, jobStatus, null, querySummary, null)
+
+        log.debug("Sending ${newJob.jobName} back to the client")
+        JSONObject result = new JSONObject()
+        result.put("jobName", jobName)
+        result.put("jobStatus", jobStatus)
+
+        result
+    }
+
     /**
      * Converts the list of selected checkboxes, into a map
      * 
@@ -84,249 +84,249 @@ class ExportService {
      */
     protected Map getHighDimDataTypesAndFormats( selectedCheckboxList ) {
         Map formats = [:]
-        
-        selectedCheckboxList.each { 
+
+        selectedCheckboxList.each {
             String[] parts = it.split("_")
-            
+
             // The third part is the export format. However,
             // for compatibility reasons the format is prepended
             // with a dot. That is not necessary anymore
-            def format = parts[2][1..-1] 
-            
+            def format = parts[2][1..-1]
+
             if( !formats.containsKey( parts[0] ) )
                 formats[parts[0]] = [:]
-                
+
             if( !formats[parts[0]].containsKey( parts[1] ) )
                 formats[parts[0]][parts[1]] = [:]
 
             if( !formats[parts[0]][parts[1]].containsKey( format ) )
                 formats[parts[0]][parts[1]][format] = []
-                
+
             formats[parts[0]][parts[1]][format] << parts[3]
         }
-        
+
         formats
     }
-    
-	def private Map getSubsetSelectedFilesMap(selectedCheckboxList) {
-		def subsetSelectedFilesMap = [:]
-        
-		//If only one was checked, we need to add that one to an array list.
+
+    def private Map getSubsetSelectedFilesMap(selectedCheckboxList) {
+        def subsetSelectedFilesMap = [:]
+
+        //If only one was checked, we need to add that one to an array list.
         if (selectedCheckboxList instanceof String)
             selectedCheckboxList = [selectedCheckboxList]
         if (selectedCheckboxList == null)
             selectedCheckboxList = []
 
-		
-		//Remove duplicates. duplicates are coming in from the UI, better handle it here
-		//The same issue is handled in the UI now so the following code may not be necessary
-		def tempArray = [] as Set
-		tempArray.addAll(selectedCheckboxList)
-		selectedCheckboxList = tempArray.toList()
-		
-		//Prepare a map like ['subset1'
-		selectedCheckboxList.each { checkboxItem ->
-			//Split the item by "_" to get the different attributes.
-			String[] checkboxItemArray = checkboxItem.split("_")
-			String currentSubset = null
-			if (checkboxItemArray.size() > 0) {
-				//The first item is the subset name.
-				currentSubset = checkboxItemArray[0].trim().replace(" ","")
-				if (null == subsetSelectedFilesMap.get(currentSubset)) subsetSelectedFilesMap.put(currentSubset, ["STUDY"])
-			}
-			
-			if (checkboxItemArray.size() > 1) {
-				//Second item is the data type.
-				String currentDataType = checkboxItemArray[1].trim()
-				if (checkboxItemArray.size()>3) {
-					def jobDataType = currentDataType+checkboxItemArray[2].trim()
-					if (!subsetSelectedFilesMap.get(currentSubset)?.contains(jobDataType)) {
-						subsetSelectedFilesMap.get(currentSubset).push(jobDataType)
-					}
-				} else if (checkboxItemArray.size()>2) {
-					subsetSelectedFilesMap.get(currentSubset)?.push(currentDataType+checkboxItemArray[2].trim())
-				} else {
-					subsetSelectedFilesMap.get(currentSubset)?.push(currentDataType)
-				}
-			}
-		}
-		
-		return subsetSelectedFilesMap
-	}
-	
-	def getsubsetSelectedPlatformsByFiles(checkboxList){
-		def subsetSelectedPlatformsByFiles=[:]
-		//Split the list on commas first, each box is seperated by ",".
-		checkboxList.each {checkboxItem ->
-			// Split the item by "_" to get the different attributes.
+
+        //Remove duplicates. duplicates are coming in from the UI, better handle it here
+        //The same issue is handled in the UI now so the following code may not be necessary
+        def tempArray = [] as Set
+        tempArray.addAll(selectedCheckboxList)
+        selectedCheckboxList = tempArray.toList()
+
+        //Prepare a map like ['subset1'
+        selectedCheckboxList.each { checkboxItem ->
+            //Split the item by "_" to get the different attributes.
+            String[] checkboxItemArray = checkboxItem.split("_")
+            String currentSubset = null
+            if (checkboxItemArray.size() > 0) {
+                //The first item is the subset name.
+                currentSubset = checkboxItemArray[0].trim().replace(" ","")
+                if (null == subsetSelectedFilesMap.get(currentSubset)) subsetSelectedFilesMap.put(currentSubset, ["STUDY"])
+            }
+
+            if (checkboxItemArray.size() > 1) {
+                //Second item is the data type.
+                String currentDataType = checkboxItemArray[1].trim()
+                if (checkboxItemArray.size()>3) {
+                    def jobDataType = currentDataType+checkboxItemArray[2].trim()
+                    if (!subsetSelectedFilesMap.get(currentSubset)?.contains(jobDataType)) {
+                        subsetSelectedFilesMap.get(currentSubset).push(jobDataType)
+                    }
+                } else if (checkboxItemArray.size()>2) {
+                    subsetSelectedFilesMap.get(currentSubset)?.push(currentDataType+checkboxItemArray[2].trim())
+                } else {
+                    subsetSelectedFilesMap.get(currentSubset)?.push(currentDataType)
+                }
+            }
+        }
+
+        subsetSelectedFilesMap
+    }
+
+    def getsubsetSelectedPlatformsByFiles(checkboxList){
+        def subsetSelectedPlatformsByFiles=[:]
+        //Split the list on commas first, each box is seperated by ",".
+        checkboxList.each {checkboxItem ->
+            // Split the item by "_" to get the different attributes.
             // Attributes are: <subset_id>_<datatype>_<exportformat>_<platform>
             // e.g. subset1_mrna_TSV_GPL570
-			String[] checkboxItemArray = StringUtils.split(checkboxItem, "_")
-			
-			//The first item is the subset name.
-			def currentSubset = checkboxItemArray[0].trim().replace(" ","")
-			
-			//Fourth item is the selected (gpl) platform
-			if(checkboxItemArray.size()>3){
-				def fileName = checkboxItemArray[1].trim()+checkboxItemArray[2].trim()
-				def platform = checkboxItemArray[3].trim()
-				if(subsetSelectedPlatformsByFiles.containsKey(currentSubset)){
-					if(subsetSelectedPlatformsByFiles.get(currentSubset).containsKey(fileName)){
-						def platformFilesList = subsetSelectedPlatformsByFiles.get(currentSubset).get(fileName)
-						platformFilesList.push(platform)
-					}else{
-						subsetSelectedPlatformsByFiles.get(currentSubset).put(fileName,[platform])
-					}
-				}else{
-					def platformsMap = new HashMap()
-					platformsMap.put(fileName,[platform])
-					subsetSelectedPlatformsByFiles.put(currentSubset,platformsMap)
-				}
-			}
-		}
-        
-		return subsetSelectedPlatformsByFiles
-	}
-	
-	def private createExportDataJob(userName, params, statusList) {
-		//Put together a hashmap with an entry for each file type we need to output.
-		def fileTypeMap = [:]
-		
-		//def jobDataTypes = ["STUDY"]; // default is always study metadata
-		
-		def selectedPlatformsByDataType
-		
-		//We need a sub hash for each subset.
-		def resultInstanceIdHashMap = [:]
-		
-		resultInstanceIdHashMap["subset1"] = params.result_instance_id1
-		resultInstanceIdHashMap["subset2"] = params.result_instance_id2
-		
-		//Loop through the values for each selected checkbox.
-		def checkboxList = params.selectedSubsetDataTypeFiles
-		
-		if(checkboxList instanceof String) {
-			def tempArray = []
-			if (checkboxList && !checkboxList?.trim().equals("")) tempArray.add(checkboxList)
-			checkboxList = tempArray
-		}
-        
-		def jdm = new JobDataMap()
-		jdm.put("analysis", params.analysis)
-		jdm.put("userName", userName)
-		jdm.put("jobName", params.jobName)
-		jdm.put("result_instance_ids", resultInstanceIdHashMap);
-		jdm.selection = params.selection
+            String[] checkboxItemArray = StringUtils.split(checkboxItem, "_")
+
+            //The first item is the subset name.
+            def currentSubset = checkboxItemArray[0].trim().replace(" ","")
+
+            //Fourth item is the selected (gpl) platform
+            if(checkboxItemArray.size()>3){
+                def fileName = checkboxItemArray[1].trim()+checkboxItemArray[2].trim()
+                def platform = checkboxItemArray[3].trim()
+                if(subsetSelectedPlatformsByFiles.containsKey(currentSubset)){
+                    if(subsetSelectedPlatformsByFiles.get(currentSubset).containsKey(fileName)){
+                        def platformFilesList = subsetSelectedPlatformsByFiles.get(currentSubset).get(fileName)
+                        platformFilesList.push(platform)
+                    }else{
+                        subsetSelectedPlatformsByFiles.get(currentSubset).put(fileName,[platform])
+                    }
+                }else{
+                    def platformsMap = new HashMap()
+                    platformsMap.put(fileName,[platform])
+                    subsetSelectedPlatformsByFiles.put(currentSubset,platformsMap)
+                }
+            }
+        }
+
+        subsetSelectedPlatformsByFiles
+    }
+
+    def private createExportDataJob(userName, params, statusList) {
+        //Put together a hashmap with an entry for each file type we need to output.
+        def fileTypeMap = [:]
+
+        //def jobDataTypes = ["STUDY"]; // default is always study metadata
+
+        def selectedPlatformsByDataType
+
+        //We need a sub hash for each subset.
+        def resultInstanceIdHashMap = [:]
+
+        resultInstanceIdHashMap["subset1"] = params.result_instance_id1
+        resultInstanceIdHashMap["subset2"] = params.result_instance_id2
+
+        //Loop through the values for each selected checkbox.
+        def checkboxList = params.selectedSubsetDataTypeFiles
+
+        if(checkboxList instanceof String) {
+            def tempArray = []
+            if (checkboxList && !checkboxList?.trim().equals("")) tempArray.add(checkboxList)
+            checkboxList = tempArray
+        }
+
+        def jdm = new JobDataMap()
+        jdm.put("analysis", params.analysis)
+        jdm.put("userName", userName)
+        jdm.put("jobName", params.jobName)
+        jdm.put("result_instance_ids", resultInstanceIdHashMap);
+        jdm.selection = params.selection
         jdm.highDimDataTypes = getHighDimDataTypesAndFormats( checkboxList )
-		jdm.put("subsetSelectedPlatformsByFiles", getsubsetSelectedPlatformsByFiles(checkboxList))
-		jdm.put("checkboxList", checkboxList);
-		jdm.put("subsetSelectedFilesMap", getSubsetSelectedFilesMap(params.selectedSubsetDataTypeFiles))
-		jdm.put("resulttype", "DataExport")
-		jdm.put("studyAccessions", i2b2ExportHelperService.findStudyAccessions(resultInstanceIdHashMap.values()) )
-		
-		//Add the pivot flag to the jobs map.
-		jdm.put("pivotData", (new Boolean(true)));
-		
-		//TODO: This should be a part of something else, config files eventually.
-		//This is hardcoded for now but it adds the step of bundling the files to a workflow.
-		jdm.put("analysisSteps",["bundle":""]);
+        jdm.put("subsetSelectedPlatformsByFiles", getsubsetSelectedPlatformsByFiles(checkboxList))
+        jdm.put("checkboxList", checkboxList);
+        jdm.put("subsetSelectedFilesMap", getSubsetSelectedFilesMap(params.selectedSubsetDataTypeFiles))
+        jdm.put("resulttype", "DataExport")
+        jdm.put("studyAccessions", i2b2ExportHelperService.findStudyAccessions(resultInstanceIdHashMap.values()) )
 
-		//This adds a step to the job to create a file link as the plugin output.
-		jdm.put("renderSteps",["FILELINK":""]);
-				
-		def jobDetail = new JobDetail(params.jobName, params.analysis, GenericJobExecutor.class)
-		jobDetail.setJobDataMap(jdm);
-		
-		// TODO -- NEED TO BE REVIEWED (f.guitton@imperial.ac.uk)
-		
-		jobDetail.getJobDataMap().put("SGA", grailsApplication);
-		jobDetail.getJobDataMap().put("SAJS", asyncJobService);
-		jobDetail.getJobDataMap().put("SJRS", jobResultsService);
-		jobDetail.getJobDataMap().put("SDES", dataExportService);
+        //Add the pivot flag to the jobs map.
+        jdm.put("pivotData", (new Boolean(true)));
 
-		// --
-		
-		if (asyncJobService.updateStatus(params.jobName, statusList[2]))	{
-			return
-		}
-		def trigger = new SimpleTrigger("triggerNow"+Math.random(), params.analysis)
-		quartzScheduler.scheduleJob(jobDetail, trigger)
-	}
-	
+        //TODO: This should be a part of something else, config files eventually.
+        //This is hardcoded for now but it adds the step of bundling the files to a workflow.
+        jdm.put("analysisSteps",["bundle":""]);
+
+        //This adds a step to the job to create a file link as the plugin output.
+        jdm.put("renderSteps",["FILELINK":""]);
+
+        def jobDetail = new JobDetail(params.jobName, params.analysis, GenericJobExecutor.class)
+        jobDetail.setJobDataMap(jdm);
+
+        // TODO -- NEED TO BE REVIEWED (f.guitton@imperial.ac.uk)
+
+        jobDetail.getJobDataMap().put("SGA", grailsApplication);
+        jobDetail.getJobDataMap().put("SAJS", asyncJobService);
+        jobDetail.getJobDataMap().put("SJRS", jobResultsService);
+        jobDetail.getJobDataMap().put("SDES", dataExportService);
+
+        // --
+
+        if (asyncJobService.updateStatus(params.jobName, statusList[2]))	{
+            return
+        }
+        def trigger = new SimpleTrigger("triggerNow"+Math.random(), params.analysis)
+        quartzScheduler.scheduleJob(jobDetail, trigger)
+    }
+
     def exportData(params, userName) {
-		def statusList = ["Started", "Validating Cohort Information",
-		 "Triggering Data-Export Job","Gathering Data","Running Conversions","Running Analysis","Rendering Output"]
-		
-		jobResultsService[params.jobName]["StatusList"] = statusList
-		asyncJobService.updateStatus(params.jobName, statusList[0])
-		 
-		def al = new AccessLog(username:userName, event:"${params.analysis}, Job: ${params.jobName}",
-		eventmessage:"", accesstime:new java.util.Date())
-		al.save()
-		 
-		//TODO get the required input parameters for the job and validate them
-		def rID1 = RequestValidator.nullCheck(params.result_instance_id1)
-		def rID2 = RequestValidator.nullCheck(params.result_instance_id2)
-		log.debug('rID1 :: ' + rID1 + ' :: rID2 :: ' + rID2)
-		asyncJobService.updateStatus(params.jobName, statusList[1])
-		
-		log.debug("Checking to see if the user cancelled the job prior to running it")
-		if (jobResultsService[params.jobName]["Status"] == "Cancelled")	{
-			log.warn("${params.jobName} has been cancelled")
-			return
-		}
-		createExportDataJob(userName, params, statusList);
-	}
-	
-	def getExportJobs(userName) {
-		JSONObject result = new JSONObject()
-		JSONArray rows = new JSONArray()
-		def maxJobs = Holders.config.com.recomdata.transmart.data.export.max.export.jobs.loaded
-		
-		maxJobs = maxJobs ? maxJobs : 0
-		
-		//TODO find out why the domain class AsyncJob was not getting imported. Is it because it is in the default package?
-		def c = AsyncJob.createCriteria()
-		def jobResults = c {
-			maxResults(maxJobs)
-			like("jobName", "${userName}%")
-			eq("jobType", "DataExport")
-			//ge("lastRunOn", new Date()-30)
-			order("id", "desc")
-		}
-		def m = [:]
-		jobResults.each	{
-			m = [:]
-			m["name"] = it.jobName
-			m["status"] = it.jobStatus
-			m["runTime"] = it.runTime
-			m["startDate"] = it.lastRunOn
-			m["viewerURL"] = it.viewerURL
-			m["querySummary"] = it.altViewerURL
-			rows.put(m)
-		}
-		
-		result.put("success", true)
-		result.put("totalCount", jobResults.size())
-		result.put("exportJobs", rows)
-		
-		return result;
-	}
-	
-	def downloadFile(params) {
-		def jobName = params.jobname
-		def job = AsyncJob.findByJobName(jobName)
-		def exportDataProcessor = new ExportDataProcessor()
+        def statusList = ["Started", "Validating Cohort Information",
+            "Triggering Data-Export Job","Gathering Data","Running Conversions","Running Analysis","Rendering Output"]
+
+        jobResultsService[params.jobName]["StatusList"] = statusList
+        asyncJobService.updateStatus(params.jobName, statusList[0])
+
+        def al = new AccessLog(username:userName, event:"${params.analysis}, Job: ${params.jobName}",
+        eventmessage:"", accesstime:new java.util.Date())
+        al.save()
+
+        //TODO get the required input parameters for the job and validate them
+        def rID1 = RequestValidator.nullCheck(params.result_instance_id1)
+        def rID2 = RequestValidator.nullCheck(params.result_instance_id2)
+        log.debug('rID1 :: ' + rID1 + ' :: rID2 :: ' + rID2)
+        asyncJobService.updateStatus(params.jobName, statusList[1])
+
+        log.debug("Checking to see if the user cancelled the job prior to running it")
+        if (jobResultsService[params.jobName]["Status"] == "Cancelled")	{
+            log.warn("${params.jobName} has been cancelled")
+            return
+        }
+        createExportDataJob(userName, params, statusList)
+    }
+
+    def getExportJobs(userName) {
+        JSONObject result = new JSONObject()
+        JSONArray rows = new JSONArray()
+        def maxJobs = Holders.config.com.recomdata.transmart.data.export.max.export.jobs.loaded
+
+        maxJobs = maxJobs ? maxJobs : 0
+
+        //TODO find out why the domain class AsyncJob was not getting imported. Is it because it is in the default package?
+        def c = AsyncJob.createCriteria()
+        def jobResults = c {
+            maxResults(maxJobs)
+            like("jobName", "${userName}%")
+            eq("jobType", "DataExport")
+            //ge("lastRunOn", new Date()-30)
+            order("id", "desc")
+        }
+        def m = [:]
+        jobResults.each	{
+            m = [:]
+            m["name"] = it.jobName
+            m["status"] = it.jobStatus
+            m["runTime"] = it.runTime
+            m["startDate"] = it.lastRunOn
+            m["viewerURL"] = it.viewerURL
+            m["querySummary"] = it.altViewerURL
+            rows.put(m)
+        }
+
+        result.put("success", true)
+        result.put("totalCount", jobResults.size())
+        result.put("exportJobs", rows)
+
+        result
+    }
+
+    def downloadFile(params) {
+        def jobName = params.jobname
+        def job = AsyncJob.findByJobName(jobName)
+        def exportDataProcessor = new ExportDataProcessor()
 
         // If com.recomdata.transmart.data.export.ftp configuration not set, ExportDataProcessor receives incorrect
         // method signature for getExportJobFileStream, so here we have used Strings instead of defs to initialize
         // the correct parameter signature
-		String tempDir = grailsApplication.config.com.recomdata.plugins.tempFolderDirectory
+        String tempDir = grailsApplication.config.com.recomdata.plugins.tempFolderDirectory
         def ftp = grailsApplication.config.com.recomdata.transmart.data.export.ftp
 
         InputStream is = exportDataProcessor.getExportJobFileStream(job.viewerURL, tempDir,
                 ftp.server ?: '', ftp.serverport ?: '21', ftp.username ?: '',
                 ftp.password ?: '', ftp.remote.path ?: '')
-		return is;
-	}
+        is
+    }
 }

--- a/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
@@ -13,6 +13,8 @@ import org.transmartproject.export.TabSeparatedExporter
 class HighDimExportService {
 
     def highDimensionResourceService
+    def highDimExporterRegistry
+    
     // FIXME: jobResultsService lives in Rmodules, so this is probably not a dependency we should have here
     def jobResultsService
 
@@ -44,7 +46,7 @@ class HighDimExportService {
                         [(AssayConstraint.ONTOLOGY_TERM_CONSTRAINT): conceptPaths.collect {[concept_key: it]}])
 
         // Setup class to export the data
-        HighDimExporter exporter = new TabSeparatedExporter()
+        HighDimExporter exporter = highDimExporterRegistry.getExporterForFormat("TSV")
         Projection projection = dataTypeResource.createProjection( exporter.projection )
 
         File outputFile = new File(studyDir, dataType + '.txt')

--- a/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
@@ -3,12 +3,12 @@ package com.recomdata.transmart.data.export
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.highdim.AssayColumn
-import org.transmartproject.core.dataquery.highdim.BioMarkerDataRow
 import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
 import org.transmartproject.core.dataquery.highdim.assayconstraints.AssayConstraint
 import org.transmartproject.core.dataquery.highdim.projections.AllDataProjection
 import org.transmartproject.core.dataquery.highdim.projections.Projection
-
+import org.transmartproject.export.HighDimExporter
+import org.transmartproject.export.TabSeparatedExporter
 
 class HighDimExportService {
 
@@ -47,19 +47,6 @@ class HighDimExportService {
         def resultInstanceId =          args.resultInstanceId
         List<String> conceptPaths =     args.conceptPaths
         String studyDir =               args.studyDir
-        
-        /*
-         dataType one of: mrna, mirna, protein, rbm, rnaseqcog, metabolite
-
-         example inputs:
-         resultInstanceId = 23306  //22967
-         conceptPaths = [/\\Public Studies\Public Studies\GSE8581\MRNA\Biomarker Data\Affymetrix Human Genome U133A 2.0 Array\Lung/]
-        */
-
-        // These maps specify the row header in the output file for each database field name.
-        Map dataFields = [rawIntensity: 'value', intensity: 'value', value: 'value', logIntensity: 'log2e', zscore: 'zscore']
-        Map rowFields = [geneSymbol: 'gene symbol', geneId: 'gene id', mirnaId: 'mirna id', peptide: 'peptide sequence',
-                antigenName: 'analyte name', uniprotId: 'uniprot id', transcriptId: 'transcript id']
 
 
         if (jobIsCancelled(jobName)) {
@@ -81,97 +68,22 @@ class HighDimExportService {
 
         AllDataProjection projection = dataTypeResource.createProjection(Projection.ALL_DATA_PROJECTION)
 
-        String[] header = ['PATIENT ID']
-        header += splitAttributeColumn ? ["SAMPLE TYPE", "TIMEPOINT", "TISSUE TYPE", "GPL ID"] : ["SAMPLE"]
-        header += ["ASSAY ID", "SAMPLE CODE"]
- 
-        Map<String, String> dataKeys = projection.dataProperties.collectEntries {[it.key, dataFieldHeaders.get(it.key, it.key).toUpperCase()]}
-        Map<String, String> rowKeys = projection.rowProperties.collectEntries {[it.key, rowFieldHeaders.get(it.key, it.key).toUpperCase()]}
+        File outputFile = new File(studyDir, dataType+'.txt')
+        String fileName = outputFile.getAbsolutePath()
 
-        header += dataKeys.values()
-        header += rowKeys.values()
-
-
-        Writer writer = null
-        String fileName = null
-        TabularResult<AssayColumn, BioMarkerDataRow<Map<String, String>>> tabularResult = null
-        long rowsFound = 0
-        long startTime
+        TabularResult<AssayColumn, DataRow<Map<String, String>>> tabularResult =
+                dataTypeResource.retrieveData(assayconstraints, [], projection)
         try {
-            File outputFile = new File(studyDir, dataType+'.txt')
-            fileName = outputFile.getAbsolutePath()
-            writer = outputFile.newWriter(true)
-
-            log.info("start sample retrieving query")
-
-            startTime = System.currentTimeMillis()
-
-            tabularResult = dataTypeResource.retrieveData(assayconstraints, [], projection)
-
-            List<AssayColumn> assayList = tabularResult.indicesList
-
-            log.info("started file writing to $fileName")
-            writer << header.join('\t') << '\n'
-
-            writeloop:
-            for (DataRow<AssayColumn,Map<String, String>> datarow : tabularResult) {
-                for (AssayColumn assay : assayList) {
-                    rowsFound++
-                    // test periodically if the job is cancelled
-                    if (rowsFound % 1024 == 0 && jobIsCancelled(jobName)) {
-                        return null
-                    }
-
-                    Map<String, String> data = datarow[assay]
-
-                    // TODO: This probably shouldn't happen, but it does!
-                    if (data == null) {
-                        continue
-                    }
-
-                    String assayId =        assay.id
-                    String patientId =      assay.patientInTrialId
-                    String sampleTypeName = assay.sampleType.label
-                    String timepointName =  assay.timepoint.label
-                    String tissueTypeName = assay.tissueType.label
-                    String platform =       assay.platform.id
-                    String sampleCode =     assay.sampleCode
-
-                    List<String> line = [patientId]
-                    if (splitAttributeColumn)
-                    //       SAMPLE TYPE     TIMEPOINT      TISSUE TYPE     GPL ID
-                        line += [sampleTypeName, timepointName, tissueTypeName, platform]
-                    else
-                    //      SAMPLE
-                        line << [sampleTypeName, timepointName, tissueTypeName, platform].grep().join('_')
-
-                    line << assayId << sampleCode
-
-                    for (String dataField: dataKeys.keySet()) {
-                        line << data[dataField]
-                    }
-
-                    for (String rowField: rowKeys.keySet()) {
-                        line << datarow."$rowField"
-                    }
-
-                    writer << line.join('\t') << '\n'
-
-                }
+            // Start exporting
+            HighDimExporter exporter = new TabSeparatedExporter()
+            outputFile.withOutputStream { outputStream ->
+                exporter.export tabularResult, projection, outputStream
             }
-            if (!rowsFound) {
-                log.error("No data found while trying to export $dataType data")
-                if (!outputFile.delete())
-                    log.error("Unable to delete empty output file $fileName")
-            }
-            log.info("Retrieving data took ${System.currentTimeMillis() - startTime} ms")
-
         } finally {
-            writer?.close()
-            tabularResult?.close()
+            tabularResult.close()
         }
 
-        return [outFile: fileName, dataFound: rowsFound]
+        return [outFile: fileName]
     }
 
     def boolean jobIsCancelled(jobName) {

--- a/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
@@ -24,6 +24,7 @@ class HighDimExportService {
         def resultInstanceId =          args.resultInstanceId
         List<String> conceptPaths =     args.conceptPaths
         String studyDir =               args.studyDir
+        String format =                 args.format
 
 
         if (jobIsCancelled(jobName)) {
@@ -45,10 +46,10 @@ class HighDimExportService {
                         [(AssayConstraint.ONTOLOGY_TERM_CONSTRAINT): conceptPaths.collect {[concept_key: it]}])
 
         // Setup class to export the data
-        HighDimExporter exporter = highDimExporterRegistry.getExporterForFormat("TSV")
+        HighDimExporter exporter = highDimExporterRegistry.getExporterForFormat( format )
         Projection projection = dataTypeResource.createProjection( exporter.projection )
 
-        File outputFile = new File(studyDir, dataType + '.txt')
+        File outputFile = new File(studyDir, dataType + '.' + format.toLowerCase() )
         String fileName = outputFile.getAbsolutePath()
 
         // Retrieve the data itself

--- a/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
@@ -21,7 +21,6 @@ class HighDimExportService {
     def exportHighDimData(Map args) {
         String jobName =                args.jobName
         String dataType =               args.dataType
-        boolean splitAttributeColumn =  args.get('splitAttributeColumn', false)
         def resultInstanceId =          args.resultInstanceId
         List<String> conceptPaths =     args.conceptPaths
         String studyDir =               args.studyDir

--- a/src/groovy/org/transmartproject/export/HighDimExporter.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimExporter.groovy
@@ -1,0 +1,47 @@
+package org.transmartproject.export
+
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+
+/**
+ * Enables exporting high dimensional data 
+ */
+interface HighDimExporter {
+    /**
+     * Determines whether a datatype is supported
+     * @param dataType Name of the datatype
+     * @return true if the datatype is supported by this exporter, false otherwise
+     */
+    public boolean isDataTypeSupported( String dataType );
+
+    /**
+     * @return A short string describing the format that is 
+     *         produced by this exporter
+     */
+    public String getFormat();
+    
+    /**
+     * @return a longer human readable description for this exporter
+     */
+    public String getDescription();
+    
+    /**
+     * Exports the data in the TabularResult to the outputStream given
+     * @param data Data to be exported
+     * @param projection Projection that was used to retrieve the data
+     * @param outputStream Stream to write the data to
+     */
+    public void export( TabularResult data, Projection projection, OutputStream outputStream );
+    
+    /**
+     * Exports the data in the TabularResult to the outputStream given, 
+     * although the export can be cancelled. Cancelling can be caused
+     * by the user or by some other process.
+     * @param data Data to be exported
+     * @param projection Projection that was used to retrieve the data
+     * @param outputStream Stream to write the data to
+     * @param isCancelled Closure that returns true iff the export is cancelled
+     */
+    public void export( TabularResult data, Projection projection, OutputStream outputStream, Closure isCancelled );
+
+}

--- a/src/groovy/org/transmartproject/export/HighDimExporter.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimExporter.groovy
@@ -12,25 +12,25 @@ interface HighDimExporter {
      * @param dataType Name of the datatype
      * @return true if the datatype is supported by this exporter, false otherwise
      */
-    public boolean isDataTypeSupported( String dataType );
+    public boolean isDataTypeSupported( String dataType )
     
     /**
      * Returns the projection name to be used for retrieving
      * data from the database
      * @return Projection name
      */
-    public String getProjection();
+    public String getProjection()
 
     /**
      * @return A short string describing the format that is 
      *         produced by this exporter
      */
-    public String getFormat();
+    public String getFormat()
     
     /**
      * @return a longer human readable description for this exporter
      */
-    public String getDescription();
+    public String getDescription()
     
     /**
      * Exports the data in the TabularResult to the outputStream given
@@ -38,7 +38,7 @@ interface HighDimExporter {
      * @param projection Projection that was used to retrieve the data
      * @param outputStream Stream to write the data to
      */
-    public void export( TabularResult data, Projection projection, OutputStream outputStream );
+    public void export( TabularResult data, Projection projection, OutputStream outputStream )
     
     /**
      * Exports the data in the TabularResult to the outputStream given, 
@@ -49,6 +49,6 @@ interface HighDimExporter {
      * @param outputStream Stream to write the data to
      * @param isCancelled Closure that returns true iff the export is cancelled
      */
-    public void export( TabularResult data, Projection projection, OutputStream outputStream, Closure isCancelled );
+    public void export( TabularResult data, Projection projection, OutputStream outputStream, Closure isCancelled )
 
 }

--- a/src/groovy/org/transmartproject/export/HighDimExporter.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimExporter.groovy
@@ -13,6 +13,13 @@ interface HighDimExporter {
      * @return true if the datatype is supported by this exporter, false otherwise
      */
     public boolean isDataTypeSupported( String dataType );
+    
+    /**
+     * Returns the projection name to be used for retrieving
+     * data from the database
+     * @return Projection name
+     */
+    public String getProjection();
 
     /**
      * @return A short string describing the format that is 

--- a/src/groovy/org/transmartproject/export/HighDimExporterRegistry.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimExporterRegistry.groovy
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 @Component
 class HighDimExporterRegistry {
     
-    protected Map<String, Class> exporterRegistry = new HashMap()
+    protected Map<String, HighDimExporter> exporterRegistry = new HashMap()
     
     /**
      * Register a new high dimensional data exporter.
@@ -13,21 +13,38 @@ class HighDimExporterRegistry {
      * @param exporterClass
      */
     void registerHighDimensionExporter(String exporterFormat,
-                                             Class<HighDimExporter> exporterClass) {
+                                             HighDimExporter exporter) {
                                              
                                              
-        this.exporterRegistry[exporterFormat] = exporterClass
+        this.exporterRegistry[exporterFormat] = exporter
         log.debug "Registered high dimensional exporter '$exporterFormat'"
     }
 
-     
+    /**
+     * Returns an exporter to export a specific named format 
+     * @param exporterFormat    Format to export
+     * @return
+     * @throws NoSuchExporterException
+     */
     HighDimExporter getExporterForFormat(String exporterFormat)
             throws NoSuchExporterException {
         if (!exporterRegistry.containsKey(exporterFormat)) {
             throw new NoSuchExporterException("Unknown format: $exporterFormat")
         }
         
-        exporterRegistry[exporterFormat].newInstance()
+        exporterRegistry[exporterFormat]
     }
-
+            
+    /**
+     * Returns a set of exporters that are able to export
+     * a certain datatype
+     * @param dataType  Name of the datatype to export
+     * @return 
+     */
+    Set<Closure<HighDimExporter>> getExportersForDataType(String dataType) {
+        return exporterRegistry.values().findAll { exporter ->
+            exporter.isDataTypeSupported( dataType ) 
+        }
+    }
+        
 }

--- a/src/groovy/org/transmartproject/export/HighDimExporterRegistry.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimExporterRegistry.groovy
@@ -1,6 +1,6 @@
 package org.transmartproject.export
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Component
 
 @Component
 class HighDimExporterRegistry {

--- a/src/groovy/org/transmartproject/export/HighDimExporterRegistry.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimExporterRegistry.groovy
@@ -1,0 +1,33 @@
+package org.transmartproject.export
+
+import org.springframework.stereotype.Component;
+
+@Component
+class HighDimExporterRegistry {
+    
+    protected Map<String, Class> exporterRegistry = new HashMap()
+    
+    /**
+     * Register a new high dimensional data exporter.
+     * @param exporterFormat
+     * @param exporterClass
+     */
+    void registerHighDimensionExporter(String exporterFormat,
+                                             Class<HighDimExporter> exporterClass) {
+                                             
+                                             
+        this.exporterRegistry[exporterFormat] = exporterClass
+        log.debug "Registered high dimensional exporter '$exporterFormat'"
+    }
+
+     
+    HighDimExporter getExporterForFormat(String exporterFormat)
+            throws NoSuchExporterException {
+        if (!exporterRegistry.containsKey(exporterFormat)) {
+            throw new NoSuchExporterException("Unknown format: $exporterFormat")
+        }
+        
+        exporterRegistry[exporterFormat].newInstance()
+    }
+
+}

--- a/src/groovy/org/transmartproject/export/NoSuchExporterException.groovy
+++ b/src/groovy/org/transmartproject/export/NoSuchExporterException.groovy
@@ -1,0 +1,6 @@
+package org.transmartproject.export
+
+import groovy.transform.InheritConstructors
+
+@InheritConstructors
+class NoSuchExporterException extends RuntimeException { }

--- a/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
@@ -49,7 +49,7 @@ class TabSeparatedExporter implements HighDimExporter {
 
     @Override
     public String getDescription() {
-        return "Tab separated file";
+        return "Tab separated file"
     }
 
     @Override

--- a/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
@@ -1,0 +1,171 @@
+package org.transmartproject.export
+
+import org.transmartproject.core.dataquery.DataRow
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.core.exceptions.NoSuchResourceException
+
+class TabSeparatedExporter implements HighDimExporter {
+    final static String SEPARATOR = "\t"
+    def highDimensionResourceService
+    
+    @Override
+    public boolean isDataTypeSupported(String dataType) {
+        // Each datatype that supports the all data projection
+        // can be exported as tsv
+        try {
+            HighDimensionDataTypeResource dataTypeResource = 
+                    highDimensionResourceService.getSubResourceForType(dataType)
+            return Projection.ALL_DATA_PROJECTION in 
+                    dataTypeResource.supportedProjections
+        } catch( NoSuchResourceException e ) {
+            // No resource found for datatype, so not supported.
+            log.warn( e.getMessage() )
+            return false
+        }
+    }
+
+    @Override
+    public String getFormat() {
+        return "TSV"
+    }
+
+    @Override
+    public String getDescription() {
+        return "Tab separated file";
+    }
+
+    @Override
+    public void export(TabularResult tabularResult, Projection projection,
+            OutputStream outputStream) {
+        export( tabularResult, projection, outputStream, { false } )
+    }
+            
+    @Override
+    public void export(TabularResult tabularResult, Projection projection,
+            OutputStream outputStream, Closure isCancelled) {
+
+        // Determine the fields to be exported, and the label they get
+        Map<String, String> dataKeys = projection.dataProperties.collectEntries {
+            [it.key, getFieldTranslation( it.key ).toUpperCase()]
+        }
+        Map<String, String> rowKeys = projection.rowProperties.collectEntries {
+            [it.key, getFieldTranslation( it.key ).toUpperCase()]
+        }
+        
+        log.info("started exporting to $format ")
+        def startTime = System.currentTimeMillis()
+        
+        outputStream.withWriter( "UTF-8" ) { writer ->
+            
+            // First write the header
+            writeLine( writer, createHeader( dataKeys.values() + rowKeys.values() ) )
+
+            // Determine the order of the assays
+            List<AssayColumn> assayList = tabularResult.indicesList
+            
+            // Start looping 
+            writeloop:
+            for (DataRow<AssayColumn,Map<String, String>> datarow : tabularResult) {
+                // Test periodically if the export is cancelled
+                if (isCancelled() ) {
+                    return null
+                }
+        
+                for (AssayColumn assay : assayList) {
+                    // Retrieve data for the current assay from the datarow
+                    Map<String, String> data = datarow[assay]
+            
+                    if (data == null) {
+                        continue
+                    }
+            
+                    // Add values for default columns
+                    List<String> line = [
+                            assay.patientInTrialId,
+                            assay.sampleType.label, 
+                            assay.timepoint.label, 
+                            assay.tissueType.label, 
+                            assay.platform.id,
+                            assay.id,
+                            assay.sampleCode
+                    ]
+            
+                    // Return data for this specific assay
+                    for (String dataField: dataKeys.keySet()) {
+                        line << data[dataField]
+                    }
+            
+                    // Return generic data for the row.
+                    for (String rowField: rowKeys.keySet()) {
+                        line << datarow."$rowField"
+                    }
+            
+                    writeLine( writer, line )
+                }
+            }
+        }
+        
+        log.info("Exporting data took ${System.currentTimeMillis() - startTime} ms")
+    }
+            
+    /**
+     * Returns a list of headers to be put into the output file
+     * @param additionalHeaderFields List of headers to be added to the 
+     *          default ones
+     * @return List of headers to be put into the output file
+     */
+    protected List<String> createHeader( List additionalHeaderFields ) {
+        [
+                "PATIENT ID",
+                "SAMPLE TYPE",
+                "TIMEPOINT",
+                "TISSUE TYPE",
+                "GPL ID",
+                "ASSAY ID",
+                "SAMPLE CODE"
+        ] + ( additionalHeaderFields ?: [] )
+    }
+            
+    /**
+     * Translates a database field name into a human readable field name in the output file. 
+     * If no translation is specified, the original name is returned
+     * @param A field that is found in the rowProperties or the dataProperties of 
+     *          the projection used
+     * @return A translation from a database field name to a field name in the output file
+     */
+    protected String getFieldTranslation( String fieldname ) {
+        // These maps specify the row header in the output file for each database field name.
+        Map translationMap = [
+                rawIntensity: 'value', 
+                intensity: 'value', 
+                value: 'value', 
+                logIntensity: 'log2e', 
+                zscore: 'zscore',
+            
+                geneSymbol: 'gene symbol', 
+                geneId: 'gene id', 
+                mirnaId: 'mirna id', 
+                peptide: 'peptide sequence',
+                antigenName: 'analyte name', 
+                uniprotId: 'uniprot id', 
+                transcriptId: 'transcript id'
+        ]
+        
+        translationMap.get( fieldname, fieldname ) 
+    }
+    
+    /**
+     * Writes a list of data to the writer, ending with a newline
+     * @param writer    Writer to write the data to
+     * @param data      List of string to be written
+     */
+    protected void writeLine( Writer writer, List<String> data ) {
+        writer << data.join(SEPARATOR) << "\n"
+        
+    }
+
+
+}

--- a/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
@@ -1,15 +1,28 @@
 package org.transmartproject.export
 
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
 import org.transmartproject.core.dataquery.highdim.projections.Projection
 import org.transmartproject.core.exceptions.NoSuchResourceException
+import org.transmartproject.db.dataquery.highdim.HighDimensionResourceService;
 
 class TabSeparatedExporter implements HighDimExporter {
     final static String SEPARATOR = "\t"
     def highDimensionResourceService
+    
+    @Autowired
+    HighDimExporterRegistry highDimExporterRegistry
+    
+    @PostConstruct
+    void init() {
+        this.highDimExporterRegistry.registerHighDimensionExporter(
+                format, this.class)
+    }
     
     @Override
     public boolean isDataTypeSupported(String dataType) {

--- a/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
@@ -13,7 +13,9 @@ import org.transmartproject.db.dataquery.highdim.HighDimensionResourceService;
 
 class TabSeparatedExporter implements HighDimExporter {
     final static String SEPARATOR = "\t"
-    def highDimensionResourceService
+
+    @Autowired
+    HighDimensionResourceService highDimensionResourceService
     
     @Autowired
     HighDimExporterRegistry highDimExporterRegistry
@@ -21,7 +23,7 @@ class TabSeparatedExporter implements HighDimExporter {
     @PostConstruct
     void init() {
         this.highDimExporterRegistry.registerHighDimensionExporter(
-                format, this.class)
+                format, this )
     }
     
     @Override

--- a/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
@@ -1,21 +1,21 @@
 package org.transmartproject.export
 
-import javax.annotation.PostConstruct;
+import javax.annotation.PostConstruct
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
+import org.transmartproject.core.dataquery.highdim.HighDimensionResource
 import org.transmartproject.core.dataquery.highdim.projections.Projection
 import org.transmartproject.core.exceptions.NoSuchResourceException
-import org.transmartproject.db.dataquery.highdim.HighDimensionResourceService;
 
 class TabSeparatedExporter implements HighDimExporter {
     final static String SEPARATOR = "\t"
 
     @Autowired
-    HighDimensionResourceService highDimensionResourceService
+    HighDimensionResource highDimensionResourceService
     
     @Autowired
     HighDimExporterRegistry highDimExporterRegistry
@@ -72,6 +72,10 @@ class TabSeparatedExporter implements HighDimExporter {
         
         log.info("started exporting to $format ")
         def startTime = System.currentTimeMillis()
+        
+        if (isCancelled() ) {
+            return null
+        }
         
         outputStream.withWriter( "UTF-8" ) { writer ->
             

--- a/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
@@ -61,14 +61,6 @@ class TabSeparatedExporter implements HighDimExporter {
     @Override
     public void export(TabularResult tabularResult, Projection projection,
             OutputStream outputStream, Closure isCancelled) {
-
-        // Determine the fields to be exported, and the label they get
-        Map<String, String> dataKeys = projection.dataProperties.collectEntries {
-            [it.key, getFieldTranslation( it.key ).toUpperCase()]
-        }
-        Map<String, String> rowKeys = projection.rowProperties.collectEntries {
-            [it.key, getFieldTranslation( it.key ).toUpperCase()]
-        }
         
         log.info("started exporting to $format ")
         def startTime = System.currentTimeMillis()
@@ -76,7 +68,16 @@ class TabSeparatedExporter implements HighDimExporter {
         if (isCancelled() ) {
             return null
         }
+
         
+        // Determine the fields to be exported, and the label they get
+        Map<String, String> dataKeys = projection.dataProperties.collectEntries {
+            [it.key, getFieldTranslation( it.key ).toUpperCase()]
+        }
+        Map<String, String> rowKeys = projection.rowProperties.collectEntries {
+            [it.key, getFieldTranslation( it.key ).toUpperCase()]
+        }
+                
         outputStream.withWriter( "UTF-8" ) { writer ->
             
             // First write the header

--- a/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
@@ -13,12 +13,12 @@ class TabSeparatedExporter implements HighDimExporter {
     
     @Override
     public boolean isDataTypeSupported(String dataType) {
-        // Each datatype that supports the all data projection
+        // Each datatype that supports the projection used
         // can be exported as tsv
         try {
             HighDimensionDataTypeResource dataTypeResource = 
                     highDimensionResourceService.getSubResourceForType(dataType)
-            return Projection.ALL_DATA_PROJECTION in 
+            return projection in 
                     dataTypeResource.supportedProjections
         } catch( NoSuchResourceException e ) {
             // No resource found for datatype, so not supported.
@@ -167,5 +167,9 @@ class TabSeparatedExporter implements HighDimExporter {
         
     }
 
+    @Override
+    public String getProjection() {
+        Projection.ALL_DATA_PROJECTION
+    }
 
 }

--- a/src/groovy/org/transmartproject/export/VCFExporter.groovy
+++ b/src/groovy/org/transmartproject/export/VCFExporter.groovy
@@ -37,7 +37,7 @@ class VCFExporter implements HighDimExporter {
 
     @Override
     public String getDescription() {
-        return "VCF formatted variants";
+        return "VCF formatted variants"
     }
 
     @Override

--- a/src/groovy/org/transmartproject/export/VCFExporter.groovy
+++ b/src/groovy/org/transmartproject/export/VCFExporter.groovy
@@ -5,12 +5,11 @@ import grails.util.Metadata
 import javax.annotation.PostConstruct
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.HighDimensionResource
 import org.transmartproject.core.dataquery.highdim.projections.Projection
-import org.transmartproject.db.dataquery.highdim.vcf.VcfDataRow
-import org.transmartproject.db.dataquery.highdim.vcf.VcfModule
 
 class VCFExporter implements HighDimExporter {
 
@@ -73,7 +72,7 @@ class VCFExporter implements HighDimExporter {
             
             // Start looping 
             writeloop:
-            for (VcfDataRow datarow : tabularResult) {
+            for (DataRow datarow : tabularResult) {
                 // Test periodically if the export is cancelled
                 if (isCancelled() ) {
                     return
@@ -107,7 +106,7 @@ class VCFExporter implements HighDimExporter {
         [ "CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT" ] + tabularResult.indicesList*.label
     }
     
-    protected List<String> getDataForPosition( VcfDataRow datarow, List<AssayColumn> assayList ) {
+    protected List<String> getDataForPosition( DataRow datarow, List<AssayColumn> assayList ) {
         def data = []
         
         // First add general info from the summary
@@ -123,7 +122,7 @@ class VCFExporter implements HighDimExporter {
 
         // TODO: Determine which info fields can be exported (if any)
         // TODO: Determine what sample-specific fields can be exported (if any) 
-        data << '.'
+        data << ''
         data << "GT"
         
         // Now add the data for each assay
@@ -142,13 +141,15 @@ class VCFExporter implements HighDimExporter {
             // new indices that were computed
             def convertedIndices = []
             [ "allele1", "allele2" ].each {
-                int oldIndex = assayData[ it ]
-                
-                if( oldIndex != null ) {
-                    String variant = originalVariants[ oldIndex ]
-                    int newIndex = newVariants.indexOf( variant )
+                if( assayData.containsKey( it ) ) {
+                    int oldIndex = assayData[ it ]
                     
-                    convertedIndices << newIndex
+                    if( oldIndex != null ) {
+                        String variant = originalVariants[ oldIndex ]
+                        int newIndex = newVariants.indexOf( variant )
+                        
+                        convertedIndices << newIndex
+                    }
                 }
             }
             
@@ -162,7 +163,7 @@ class VCFExporter implements HighDimExporter {
     
     @Override
     public String getProjection() {
-        VcfModule.COHORT_PROJECTION
+        "cohort"
     }
 
 }

--- a/src/groovy/org/transmartproject/export/VCFExporter.groovy
+++ b/src/groovy/org/transmartproject/export/VCFExporter.groovy
@@ -7,15 +7,15 @@ import javax.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.HighDimensionResource
 import org.transmartproject.core.dataquery.highdim.projections.Projection
-import org.transmartproject.db.dataquery.highdim.HighDimensionResourceService
 import org.transmartproject.db.dataquery.highdim.vcf.VcfDataRow
 import org.transmartproject.db.dataquery.highdim.vcf.VcfModule
 
 class VCFExporter implements HighDimExporter {
 
     @Autowired
-    HighDimensionResourceService highDimensionResourceService
+    HighDimensionResource highDimensionResourceService
     
     @Autowired
     HighDimExporterRegistry highDimExporterRegistry
@@ -54,6 +54,10 @@ class VCFExporter implements HighDimExporter {
         log.info("started exporting to $format ")
         def startTime = System.currentTimeMillis()
         
+        if (isCancelled() ) {
+            return
+        }
+
         outputStream.withWriter( "UTF-8" ) { writer ->
             
             // Write the headers
@@ -72,7 +76,7 @@ class VCFExporter implements HighDimExporter {
             for (VcfDataRow datarow : tabularResult) {
                 // Test periodically if the export is cancelled
                 if (isCancelled() ) {
-                    return null
+                    return
                 }
                 
                 writer << getDataForPosition( datarow, assayList ).join( "\t" ) << "\n"

--- a/src/groovy/org/transmartproject/export/VCFExporter.groovy
+++ b/src/groovy/org/transmartproject/export/VCFExporter.groovy
@@ -1,0 +1,164 @@
+package org.transmartproject.export
+
+import grails.util.Metadata
+
+import javax.annotation.PostConstruct
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.db.dataquery.highdim.HighDimensionResourceService
+import org.transmartproject.db.dataquery.highdim.vcf.VcfDataRow
+import org.transmartproject.db.dataquery.highdim.vcf.VcfModule
+
+class VCFExporter implements HighDimExporter {
+
+    @Autowired
+    HighDimensionResourceService highDimensionResourceService
+    
+    @Autowired
+    HighDimExporterRegistry highDimExporterRegistry
+    
+    @PostConstruct
+    void init() {
+        this.highDimExporterRegistry.registerHighDimensionExporter(
+                format, this )
+    }
+    
+    @Override
+    public boolean isDataTypeSupported(String dataType) {
+        return dataType == "vcf"
+    }
+
+    @Override
+    public String getFormat() {
+        return "VCF"
+    }
+
+    @Override
+    public String getDescription() {
+        return "VCF formatted variants";
+    }
+
+    @Override
+    public void export(TabularResult tabularResult, Projection projection,
+            OutputStream outputStream) {
+        export( tabularResult, projection, outputStream, { false } )
+    }
+            
+    @Override
+    public void export(TabularResult tabularResult, Projection projection,
+            OutputStream outputStream, Closure isCancelled) {
+
+        log.info("started exporting to $format ")
+        def startTime = System.currentTimeMillis()
+        
+        outputStream.withWriter( "UTF-8" ) { writer ->
+            
+            // Write the headers
+            headers.each {
+                writer << "##" << it << "\n"
+            }
+            
+            // Write the header row for the data
+            writer << "#" << getDataColumns( tabularResult ).join( "\t" ) << "\n"
+            
+            // Determine the order of the assays
+            List<AssayColumn> assayList = tabularResult.indicesList
+            
+            // Start looping 
+            writeloop:
+            for (VcfDataRow datarow : tabularResult) {
+                // Test periodically if the export is cancelled
+                if (isCancelled() ) {
+                    return null
+                }
+                
+                writer << getDataForPosition( datarow, assayList ).join( "\t" ) << "\n"
+            }
+        }
+        
+        log.info("Exporting data took ${System.currentTimeMillis() - startTime} ms")
+    }
+            
+    /**
+     * Returns a list of VCF headers to be put into the output file
+     * @return List of headers to be put into the output file
+     */
+    protected List<String> getHeaders() {
+        [
+            "fileformat=VCFv4.2",
+            "fileDate=" + new Date().format('yyyyMMdd'),
+            "source=transmart v" + Metadata.current[ "app.version" ]
+        ]
+    }
+    
+    /**
+     * Returns a list with all the columns 
+     * @param tabularResult
+     * @return
+     */
+    protected List<String> getDataColumns( TabularResult tabularResult ) {
+        [ "CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT" ] + tabularResult.indicesList*.label
+    }
+    
+    protected List<String> getDataForPosition( VcfDataRow datarow, List<AssayColumn> assayList ) {
+        def data = []
+        
+        // First add general info from the summary
+        data << datarow.chromosome
+        data << datarow.position
+        data << datarow.rsId
+        data << datarow.cohortInfo.referenceAllele
+        data << datarow.cohortInfo.alternativeAlleles.join(',')
+        
+        // TODO: Determine whether these values still apply for the cohort selected
+        data << datarow.quality
+        data << datarow.filter
+
+        // TODO: Determine which info fields can be exported (if any)
+        // TODO: Determine what sample-specific fields can be exported (if any) 
+        data << '.'
+        data << "GT"
+        
+        // Now add the data for each assay
+        List<String> originalVariants = [] + datarow.referenceAllele + datarow.alternativeAlleles
+        List<String> newVariants = datarow.cohortInfo.alleles
+        for (AssayColumn assay : assayList) {
+            // Retrieve data for the current assay from the datarow
+            Map<String, String> assayData = datarow[assay]
+    
+            if (assayData == null) {
+                data << "."
+                continue
+            }
+    
+            // Convert the old indices (e.g. 1 and 0) to the
+            // new indices that were computed
+            def convertedIndices = []
+            [ "allele1", "allele2" ].each {
+                int oldIndex = assayData[ it ]
+                
+                if( oldIndex != null ) {
+                    String variant = originalVariants[ oldIndex ]
+                    int newIndex = newVariants.indexOf( variant )
+                    
+                    convertedIndices << newIndex
+                }
+            }
+            
+            // Convert the both alleles into a single string
+            // TODO: Take phase of the original read into account (unphased or phased, / or |)
+            data << convertedIndices.join( "/" )
+        }
+
+        data
+    }
+    
+    @Override
+    public String getProjection() {
+        VcfModule.COHORT_PROJECTION
+    }
+
+}

--- a/test/unit/com/recomdata/transmart/data/export/ExportServiceSpec.groovy
+++ b/test/unit/com/recomdata/transmart/data/export/ExportServiceSpec.groovy
@@ -1,0 +1,69 @@
+package com.recomdata.transmart.data.export
+
+import grails.test.mixin.*
+import grails.test.mixin.support.*
+
+import org.junit.*
+
+import spock.lang.Specification
+
+/**
+ * See the API for {@link grails.test.mixin.support.GrailsUnitTestMixin} for usage instructions
+ */
+@TestMixin(GrailsUnitTestMixin)
+@TestFor(ExportService)
+class ExportServiceSpec extends Specification {
+
+    void "test getHighDimDataTypesAndFormats basic functionality"() {
+        given: "a set of selected checkboxes"
+        def selectedCheckBoxList = [
+            "subset1_mrna_.TXT_GPL570",
+            "subset1_mrna_.TXT_GPL571",
+            "subset1_mrna_.XLS_GPL570",
+            "subset1_mirna_.TXT_GPL570",
+            "subset2_mrna_.TXT_GPL570",
+        ]
+            
+        when: "the strings are parsed"
+        def formats = service.getHighDimDataTypesAndFormats(selectedCheckBoxList)
+        
+        then: "the output is a properly formatted map"
+        // Expected
+        //      subset1={mrna={TXT=[GPL570, GPL571], XLS=[GPL570]}, mirna={TXT=[GPL570]}}
+        //      subset2={mrna={TXT=[GPL570]}}
+        formats.keySet().size() == 2
+        formats.containsKey( "subset1" )
+        formats.containsKey( "subset2" )
+        
+        formats.subset1.keySet().size() == 2
+        formats.subset1.containsKey( "mrna" )
+        formats.subset1.containsKey( "mirna" )
+
+        formats.subset1.mrna.keySet().size() == 2
+        formats.subset1.mrna.containsKey( "TXT" )
+        formats.subset1.mrna.containsKey( "XLS" )
+
+        formats.subset1.mrna.TXT.size() == 2
+        formats.subset1.mrna.TXT.contains( "GPL570" )
+        formats.subset1.mrna.TXT.contains( "GPL571" )
+
+        formats.subset1.mrna.XLS.size() == 1
+        formats.subset1.mrna.XLS.contains( "GPL570" )
+        
+        formats.subset1.mirna.keySet().size() == 1
+        formats.subset1.mirna.containsKey( "TXT" )
+
+        formats.subset1.mirna.TXT.size() == 1
+        formats.subset1.mirna.TXT.contains( "GPL570" )
+
+        formats.subset2.keySet().size() == 1
+        formats.subset2.containsKey( "mrna" )
+
+        formats.subset2.mrna.keySet().size() == 1
+        formats.subset2.mrna.containsKey( "TXT" )
+
+        formats.subset2.mrna.TXT.size() == 1
+        formats.subset2.mrna.TXT.contains( "GPL570" )
+
+    }
+}

--- a/test/unit/org/transmartproject/export/MockTabularResultHelper.groovy
+++ b/test/unit/org/transmartproject/export/MockTabularResultHelper.groovy
@@ -1,0 +1,131 @@
+package org.transmartproject.export
+
+import grails.test.mixin.*
+
+import org.gmock.GMockController
+import org.transmartproject.core.dataquery.DataRow
+import org.transmartproject.core.dataquery.Patient
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.SampleType
+import org.transmartproject.core.dataquery.assay.Timepoint
+import org.transmartproject.core.dataquery.assay.TissueType
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.Platform
+
+class MockTabularResultHelper {
+
+    GMockController gMockController
+
+    List<AssayColumn> createSampleAssays(int n) {
+        (1..n).collect {
+            createMockAssay( it, "assay_${it}", "sample_code_${it}", 
+                    "patient_${it}_subject_id", "sampletype_${it}",
+                    "timepoint_${it}", "tissuetype_${it}", "" + it * 10 )
+        }
+    }
+
+    DataRow createRowForAssays(List<AssayColumn> assays,
+                               List<Double> data,
+                               String label) {
+        createMockRow(
+                dot(assays, data, {a, b -> [ a, b ]})
+                        .collectEntries(Closure.IDENTITY),
+                label)
+    }
+
+    List dot(List list1, List list2, function) {
+        def res = []
+        for (int i = 0; i < list1.size(); i++) {
+            res << function(list1[i], list2[i])
+        }
+        res
+    }
+
+    List<Patient> createPatients(int n) {
+        (1..n).collect {
+            Patient p = mock(Patient)
+            p.inTrialId.returns("subject id #$it".toString()).atLeastOnce()
+            p
+        }
+    }
+
+    List<String> createPatientRowLabels(int n) {
+        (1..n).collect {
+            "patient #$it" as String
+        }
+    }
+
+    TabularResult<AssayColumn, DataRow> createMockTabularResult(Map params) {
+        List<AssayColumn> sampleAssays        = params.assays
+        Map<String, List<Object>> labelToData = params.data
+        String columnsDimensionLabel          = params.columnsLabel
+        String rowsDimensionLabel             = params.rowsLabel
+
+        def iterator = labelToData.collect { String label, List<Number> data ->
+            createRowForAssays(sampleAssays, data, label)
+        }.iterator()
+                
+        TabularResult highDimResult = mock TabularResult
+        highDimResult.indicesList.returns(sampleAssays).stub()
+        highDimResult.getRows().returns(iterator).stub()
+        highDimResult.iterator().returns(iterator).stub()
+        
+        if (columnsDimensionLabel) {
+            highDimResult.columnsDimensionLabel.returns columnsDimensionLabel
+        }
+        if (rowsDimensionLabel) {
+            highDimResult.rowsDimensionLabel.returns rowsDimensionLabel
+        }
+
+        highDimResult
+    }
+
+
+    private AssayColumn createMockAssay(
+            Long id = null, String label = null, String sampleCode = null, 
+            String patientInTrialId = null, String sampleTypeLabel = null,
+            String timepointLabel = null, String tissueTypeLabel = null,
+            String platformId = null 
+            ) {
+        [
+                getId:               { -> id },
+                getLabel:            { -> label },
+                getSampleCode:       { -> sampleCode },
+                getPatientInTrialId: { -> patientInTrialId },
+                getSampleType:       { -> [ 
+                        getLabel:       { -> sampleTypeLabel }
+                ] as SampleType },
+                getTimepoint:       { -> [ 
+                        getLabel:       { -> timepointLabel }
+                ] as Timepoint },
+                getTissueType:       { -> [ 
+                        getLabel:       { -> tissueTypeLabel }
+                ] as TissueType },
+                getPlatform:       { -> [ 
+                        getId:       { -> platformId }
+                ] as Platform },
+                equals:              { other -> delegate.is(other) },
+                toString:            { -> "assay for $patientInTrialId" as String }
+        ] as AssayColumn
+    }
+    
+    private DataRow<AssayColumn, Object> createMockRow(Map<AssayColumn, Object> values,
+                                                       String label) {
+        DataRow row = mock(DataRow)
+        row.label.returns(label).stub()
+
+        values.eachWithIndex { entry, i ->
+            row.getAt(i).returns(entry.value).stub()
+        }
+        values.keySet().each { column ->
+            row.getAt(column).returns(values[column]).stub()
+        }
+        row.iterator().returns(values.values().iterator()).stub()
+
+        row
+    }
+
+    private Object mock(Class clazz) {
+        gMockController.mock clazz
+    }
+}

--- a/test/unit/org/transmartproject/export/TabSeparatedExporterTests.groovy
+++ b/test/unit/org/transmartproject/export/TabSeparatedExporterTests.groovy
@@ -1,0 +1,147 @@
+package org.transmartproject.export
+
+import grails.test.mixin.*
+
+import java.nio.charset.Charset
+
+import org.gmock.WithGMock
+import org.junit.Before
+import org.junit.Test
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
+import org.transmartproject.core.dataquery.highdim.HighDimensionResource
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.core.exceptions.NoSuchResourceException
+
+import spock.lang.*
+
+/**
+ *
+ */
+@WithGMock
+class TabSeparatedExporterTests {
+    @Delegate
+    MockTabularResultHelper mockTabularResultHelper
+    
+    TabSeparatedExporter exporter
+    TabularResult tabularResult
+    Projection projection
+    
+    @Before
+    void before() {
+        mockTabularResultHelper = new MockTabularResultHelper()
+        mockTabularResultHelper.gMockController = $gmockController
+        
+        // Setup exporter
+        exporter = new TabSeparatedExporter()
+    }
+
+    @Test
+    void "test whether supported datatypes are recognized"() {
+        
+        def mrnaResource = mock(HighDimensionDataTypeResource) {
+            getSupportedProjections().returns( [ "all_data" ] )
+        }
+        
+        def mirnaResource = mock(HighDimensionDataTypeResource) {
+            getSupportedProjections().returns( [ "default_real_projection", "some_other_projection", "all_data" ] )
+        }
+        
+        def otherResource = mock(HighDimensionDataTypeResource) {
+            getSupportedProjections().returns( [ "default_real_projection", "some_other_projection" ] )
+        }
+        
+        def resourceService = mock(HighDimensionResource) {
+            getSubResourceForType( "mrna" ).returns( mrnaResource )
+            getSubResourceForType( "mirna" ).returns( mirnaResource )
+            getSubResourceForType( "other" ).returns( otherResource )
+            getSubResourceForType( null ).raises( new NoSuchResourceException("Unknown data type: null") )
+            getSubResourceForType( "unknownFormat" ).raises( new NoSuchResourceException("Unknown data type: other") )
+        }
+        
+        exporter.highDimensionResourceService = resourceService
+
+        play {
+            // Tab separated export is supported on every datatype
+            // with ALL_DATA_PROJECTION
+            assert exporter.isDataTypeSupported( "mrna" )
+            assert exporter.isDataTypeSupported( "mirna" )
+            
+            assert !exporter.isDataTypeSupported( "other" )
+            assert !exporter.isDataTypeSupported( null )
+            assert !exporter.isDataTypeSupported( "unknownFormat" )
+        }
+     }
+    
+    @Test
+    void "test whether a cancelled export doesn't produce output"() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        
+        def tabularResult = mock(TabularResult)
+        def projection = mock(Projection)
+        
+        play {
+            
+            exporter.export( tabularResult, projection, outputStream, { true } )
+            
+            // As the export is cancelled, 
+            assert !outputStream.toString()
+        }
+     }
+
+    @Test
+    void "test whether a basic tabular result is exported properly"() {
+        // Setup tabularResult and projection to test with
+        List<AssayColumn> sampleAssays        = createSampleAssays(2)
+        Map<String, List<Object>> labelToData = [ 
+            "row1": [[ "property1": 4, ], [ "property1": 2, "property2": 3]],  
+            "row2": [[ "property1": 5, "property2": 10], null], 
+        ]
+        tabularResult = createMockTabularResult( assays: sampleAssays, data: labelToData )
+        
+        // Create all data projection, as that is used for exporting tab separated files
+        def projection = mock(Projection) {
+            getRowProperties().returns( [ "label": String ] )
+            getDataProperties().returns( [ "property1": Integer, "property2": Integer ])
+        }
+        
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        
+        play {
+            exporter.export( tabularResult, projection, outputStream )
+            
+            // Assert we have at least some text, in UTF-8 encoding
+            String output = outputStream.toString("UTF-8")
+            assert output
+            
+            // We expect 4 lines: 1 header line, two lines  for assay 1, and one line for assay 2
+            List lines = output.readLines()
+            assert lines.size() == 4
+            
+            // Check header line
+            assert lines[0] == [ 
+                    "PATIENT ID", "SAMPLE TYPE", "TIMEPOINT", "TISSUE TYPE", "GPL ID", "ASSAY ID", "SAMPLE CODE", 
+                    "PROPERTY1", "PROPERTY2", 
+                    "LABEL" ].join( exporter.SEPARATOR )
+                    
+            // Check the data lines. First line should contain 'null' for property2, as that one was not set
+            assert lines[1] == [
+                    "patient_1_subject_id", "sampletype_1", "timepoint_1", "tissuetype_1", "10", "1", "sample_code_1",
+                    "4", "null",
+                    "row1" ].join( exporter.SEPARATOR )
+                
+            assert lines[2] == [
+                    "patient_2_subject_id", "sampletype_2", "timepoint_2", "tissuetype_2", "20", "2", "sample_code_2",
+                    "2", "3",
+                    "row1" ].join( exporter.SEPARATOR )
+                
+            assert lines[3] == [
+                    "patient_1_subject_id", "sampletype_1", "timepoint_1", "tissuetype_1", "10", "1", "sample_code_1",
+                    "5", "10",
+                    "row2" ].join( exporter.SEPARATOR )
+            
+        }
+     }
+
+}

--- a/test/unit/org/transmartproject/export/VCFExporterTests.groovy
+++ b/test/unit/org/transmartproject/export/VCFExporterTests.groovy
@@ -1,0 +1,199 @@
+package org.transmartproject.export
+
+import grails.test.mixin.*
+
+import org.gmock.WithGMock
+import org.junit.Before
+import org.junit.Test
+import org.transmartproject.core.dataquery.DataRow
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.core.dataquery.highdim.vcf.VcfCohortInfo
+
+import spock.lang.*
+
+/**
+ *
+ */
+@WithGMock
+class VCFExporterTests {
+    @Delegate
+    MockTabularResultHelper mockTabularResultHelper
+    
+    VCFExporter exporter
+    TabularResult tabularResult
+    Projection projection
+    
+    @Before
+    void before() {
+        mockTabularResultHelper = new MockTabularResultHelper()
+        mockTabularResultHelper.gMockController = $gmockController
+        
+        // Setup exporter
+        exporter = new VCFExporter()
+    }
+
+    @Test
+    void "test whether supported datatypes are recognized"() {
+        // Only VCF datatype is supported
+        assert exporter.isDataTypeSupported( "vcf" )
+        
+        assert !exporter.isDataTypeSupported( "other" )
+        assert !exporter.isDataTypeSupported( null )
+     }
+    
+    @Test
+    void "test whether a cancelled export doesn't produce output"() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        
+        def tabularResult = mock(TabularResult)
+        def projection = mock(Projection)
+        
+        play {
+            
+            exporter.export( tabularResult, projection, outputStream, { true } )
+            
+            // As the export is cancelled, 
+            assert !outputStream.toString()
+        }
+     }
+
+    @Test
+    void "test whether a basic tabular result is exported properly"() {
+        tabularResult = createMockVCFTabularResult()
+        
+        // Create cohort projection, as that is used for exporting tab separated files
+        def projection = mock(Projection)
+        
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        
+        play {
+            exporter.export( tabularResult, projection, outputStream )
+            
+            // Assert we have at least some text, in UTF-8 encoding
+            String output = outputStream.toString("UTF-8")
+            assert output
+            
+            // We expect 4 lines: 1 header line, two lines  for assay 1, and one line for assay 2
+            List lines = output.readLines()
+            assert lines.size() == 7
+            
+            expectHeader( lines[0..2] )
+            expectDataHeader( lines[3] )
+            
+            // Check first chromosome
+            assert lines[4] == [
+                    "1", "100", "rs0010", "G", "", "50", "PASS", "", "GT",
+                    "0/0", "0/0" ].join( "\t" )
+                
+            assert lines[5] == [
+                    "2", "190", ".", "A", "G", "90", "q10", "", "GT",   // Inversion of reference and alternatives
+                    "1/0", "0/0" ].join( "\t" )
+                
+            assert lines[6] == [
+                    "X", "190", ".", "G", "A", "90", "PASS", "", "GT",    
+                    "0", "1" ].join( "\t" )
+            
+        }
+     }
+    
+    
+    protected expectHeader( List<String> headerLines ) {
+        assert headerLines[0].equals( "##fileformat=VCFv4.2" )
+        assert headerLines[1].equals( "##fileDate=" + new Date().format('yyyyMMdd') )
+        assert headerLines[2].startsWith( "##source=transmart" )
+    }
+    
+    protected expectDataHeader( String dataHeaderLine ) {
+        assert dataHeaderLine == "#" + [
+            "CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT",
+            "assay_1", "assay_2" ].join( "\t" )
+
+    }
+    
+    protected createMockVCFTabularResult() {
+        // Setup tabularResult and projection to test with
+        List<AssayColumn> sampleAssays = createSampleAssays(2)
+        Map<String, List<Object>> labelToData = [
+            "row1": [[ "allele1": 0, "allele2": 0 ], [ "allele1": 0, "allele2": 0 ]],
+            "row2": [[ "allele1": 0, "allele2": 1 ], [ "allele1": 1, "allele2": 1 ]],
+            "row3": [[ "allele1": 0 ], [ "allele1": 1 ]],   // X chromosome
+        ]
+        
+        Map<String,Map> vcfProperties = [
+            "row1": [ chromosome: 1, position: 100, rsId: "rs0010", 
+                    referenceAllele: "G", alternativeAlleles: [], 
+                    quality: 50, filter: "PASS", cohortInfo: [
+                            referenceAllele: "G",
+                            alternativeAlleles: [],
+                            alleles: [ "G" ]
+                    ]],
+            "row2": [ chromosome: 2, position: 190, rsId: ".", 
+                    referenceAllele: "G", alternativeAlleles: [ "A" ], 
+                    quality: 90, filter: "q10", cohortInfo: [
+                            referenceAllele: "A",
+                            alternativeAlleles: [ "G" ],
+                            alleles: [ "A", "G" ]
+                    ]],
+            "row3": [ chromosome: "X", position: 190, rsId: ".", 
+                    referenceAllele: "G", alternativeAlleles: [ "A" ], 
+                    quality: 90, filter: "PASS", cohortInfo: [
+                            referenceAllele: "G",
+                            alternativeAlleles: [ "A" ],
+                            alleles: [ "G", "A" ]
+                    ]],
+        ]
+
+        
+        def iterator = labelToData.collect { String label, List<Object> data ->
+            createVCFRowForAssays(sampleAssays, data, vcfProperties[ label ], label)
+        }.iterator()
+                
+        TabularResult highDimResult = mock TabularResult
+        highDimResult.indicesList.returns(sampleAssays).stub()
+        highDimResult.getRows().returns(iterator).stub()
+        highDimResult.iterator().returns(iterator).stub()
+        
+        highDimResult
+    }
+    
+    DataRow createVCFRowForAssays(List<AssayColumn> assays,
+            List<Object> data,
+            Map<String,Object> vcfProperties, 
+            String label) {
+        createMockVCFRow(
+                dot(assays, data, {a, b -> [ a, b ]})
+                         .collectEntries(Closure.IDENTITY),
+                vcfProperties,
+                label)
+    }
+            
+    private DataRow<AssayColumn, Object> createMockVCFRow(Map<AssayColumn, Object> values,
+            Map<String,Object> vcfProperties, String label) {
+        DataRow row = mock(DataRow)
+        row.label.returns(label).stub()
+        
+        row.chromosome.returns( vcfProperties.chromosome ).stub()
+        row.position.returns( vcfProperties.position ).stub()
+        row.rsId.returns( vcfProperties.rsId ).stub()
+        row.referenceAllele.returns( vcfProperties.referenceAllele ).stub()
+        row.alternativeAlleles.returns( vcfProperties.alternativeAlleles ).stub()
+        row.quality.returns( vcfProperties.quality ).stub()
+        row.filter.returns( vcfProperties.filter ).stub()
+        row.cohortInfo.returns(vcfProperties.cohortInfo).stub()
+
+        // Add values for each assay
+        
+        values.eachWithIndex { entry, i ->
+            row.getAt(i).returns(entry.value).stub()
+        }
+        values.keySet().each { column ->
+            row.getAt(column).returns(values[column]).stub()
+        }
+        row.iterator().returns(values.values().iterator()).stub()
+        
+        row
+    }
+
+}


### PR DESCRIPTION
The export functionality is split into a part to retrieve the data, and the part to actually write the output file. The latter is put into classes implementing the HighDimExporter interface. This allows us to develop different types of export file formats, independent of the way the data is retrieved from the database.
