### PR TITLE
Update label in data types view.

### DIFF
--- a/grails-app/views/ontology/_showDataTypes.gsp
+++ b/grails-app/views/ontology/_showDataTypes.gsp
@@ -2,7 +2,7 @@
 <h2>Data types:</h2>
 <table class="detail">
     <tr class="prop">
-      <td valign="top" class="name">HD Molecular Data Types</td>
+      <td valign="top" class="name">Molecular Data Types</td>
       <td valign="top" class="value">${dataTypes.join(", ")}</td>
     </tr>
 </table>


### PR DESCRIPTION
Removed 'HD' from 'HD Molecular Data Types' label.
